### PR TITLE
Remove netns usage in tests cause

### DIFF
--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -114,7 +114,7 @@ func (c *ExternalIpController) worker() {
 			cidr = t.Cidr
 		}
 		if err != nil {
-			glog.Errorf("Error assigning IP %v - %v", cidr, err)
+			glog.Errorf("Error assigning IP %s on %s - %v", cidr, c.Iface, err)
 			c.queue.Add(item)
 		} else {
 			glog.V(2).Infof("IP %v was successfull assigned", cidr)


### PR DESCRIPTION
It is not that simple to enforce different threads to use same netns.
LockOSThread won't help if inside gorouting you are spawning more of them