### PR TITLE
Improve containerized-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ test.test
 vendor/
 _output/
 workdir/
+
+*.complete


### PR DESCRIPTION
Download dependencies in container to avoid glide installation
on host machine.