### PR TITLE
Add IpClaimPool k8s third party resource

### DIFF
--- a/pkg/extensions/register.go
+++ b/pkg/extensions/register.go
@@ -22,10 +22,14 @@ import (
 )
 
 func EnsureThirdPartyResourcesExist(clientset *kubernetes.Clientset) error {
-	if err := ensureThirdPartyResource(clientset, "ip-node"); err != nil {
-		return err
+	resourceNames := []string{"ip-node", "ip-claim", "ip-claim-pool"}
+	for _, resName := range resourceNames {
+		if err := ensureThirdPartyResource(clientset, resName); err != nil {
+			return err
+		}
 	}
-	return ensureThirdPartyResource(clientset, "ip-claim")
+
+	return nil
 }
 
 func ensureThirdPartyResource(clientset *kubernetes.Clientset, name string) error {

--- a/pkg/extensions/testing/client.go
+++ b/pkg/extensions/testing/client.go
@@ -24,8 +24,9 @@ import (
 
 type FakeExtClientset struct {
 	mock.Mock
-	Ipclaims *fakeIpClaims
-	Ipnodes  *fakeIpNodes
+	Ipclaims     *fakeIpClaims
+	Ipnodes      *fakeIpNodes
+	Ipclaimpools *fakeIpClaimPools
 }
 
 func (f *FakeExtClientset) IPClaims() extensions.IPClaimsInterface {
@@ -34,6 +35,10 @@ func (f *FakeExtClientset) IPClaims() extensions.IPClaimsInterface {
 
 func (f *FakeExtClientset) IPNodes() extensions.IPNodesInterface {
 	return f.Ipnodes
+}
+
+func (f *FakeExtClientset) IPClaimPools() extensions.IPClaimPoolsInterface {
+	return f.Ipclaimpools
 }
 
 type fakeIpClaims struct {
@@ -102,9 +107,34 @@ func (f *fakeIpNodes) Watch(_ api.ListOptions) (watch.Interface, error) {
 	return nil, nil
 }
 
+type fakeIpClaimPools struct {
+	mock.Mock
+}
+
+func (f *fakeIpClaimPools) Create(ipclaimpool *extensions.IpClaimPool) (*extensions.IpClaimPool, error) {
+	args := f.Called(ipclaimpool)
+	return ipclaimpool, args.Error(0)
+}
+
+func (f *fakeIpClaimPools) List(opts api.ListOptions) (*extensions.IpClaimPoolList, error) {
+	args := f.Called(opts)
+	return args.Get(0).(*extensions.IpClaimPoolList), args.Error(1)
+}
+
+func (f *fakeIpClaimPools) Delete(name string, opts *api.DeleteOptions) error {
+	args := f.Called(name, opts)
+	return args.Error(0)
+}
+
+func (f *fakeIpClaimPools) Get(name string) (*extensions.IpClaimPool, error) {
+	args := f.Called(name)
+	return args.Get(0).(*extensions.IpClaimPool), args.Error(1)
+}
+
 func NewFakeExtClientset() *FakeExtClientset {
 	return &FakeExtClientset{
-		Ipclaims: &fakeIpClaims{},
-		Ipnodes:  &fakeIpNodes{},
+		Ipclaims:     &fakeIpClaims{},
+		Ipnodes:      &fakeIpNodes{},
+		Ipclaimpools: &fakeIpClaimPools{},
 	}
 }

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -41,6 +41,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&IpNodeList{},
 		&IpClaim{},
 		&IpClaimList{},
+		&IpClaimPool{},
+		&IpClaimPoolList{},
 
 		&api.ListOptions{},
 		&api.DeleteOptions{},
@@ -123,11 +125,65 @@ type IpClaimSpec struct {
 	Link     string `json:"link" protobuf:"bytes,10,opt,name=link"`
 }
 
+type IpClaimPool struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Standard object metadata
+	Metadata api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Spec IpClaimPoolSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
+}
+
+func (e *IpClaimPool) GetObjectKind() unversioned.ObjectKind {
+	return &e.TypeMeta
+}
+
+func (e *IpClaimPool) GetObjectMeta() meta.Object {
+	return &e.Metadata
+}
+
+type IpClaimPoolSpec struct {
+	Range string `json:"range" protobuf:"bytes,10,opt,name=range"`
+}
+
+type IpClaimPoolList struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Standard list metadata.
+	unversioned.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Items []IpClaimPool `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
 // see https://github.com/kubernetes/client-go/issues/8
 type ExampleIpNode IpNode
 type ExampleIpNodesList IpNodeList
 type ExampleIpClaim IpClaim
 type ExampleIpClaimList IpClaimList
+type ExampleIpClaimPool IpClaimPool
+type ExampleIpClaimPoolList IpClaimPoolList
+
+func (e *IpClaimPool) UnmarshalJSON(data []byte) error {
+	tmp := ExampleIpClaimPool{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := IpClaimPool(tmp)
+	*e = tmp2
+	return nil
+}
+
+func (e *IpClaimPoolList) UnmarshalJSON(data []byte) error {
+	tmp := ExampleIpClaimPoolList{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := IpClaimPoolList(tmp)
+	*e = tmp2
+	return nil
+}
 
 func (e *IpNode) UnmarshalJSON(data []byte) error {
 	tmp := ExampleIpNode{}


### PR DESCRIPTION
The resource defines IP pool (in form of range) from which external IPs
will be auto allocated for k8s services that request such allocation.