### PR TITLE
Add option to resync state for all ipclaims/services

### DIFF
--- a/cmd/app/controller.go
+++ b/cmd/app/controller.go
@@ -60,7 +60,7 @@ func InitController() error {
 		return err
 	}
 	stop := make(chan struct{})
-	c, err := claimcontroller.NewClaimController(iface, uid, config)
+	c, err := claimcontroller.NewClaimController(iface, uid, config, AppOpts.ResyncInterval)
 	if err != nil {
 		return err
 	}

--- a/cmd/app/naive.go
+++ b/cmd/app/naive.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/1.5/tools/clientcmd"
 
 	externalip "github.com/Mirantis/k8s-externalipcontroller/pkg"
-	"github.com/Mirantis/k8s-externalipcontroller/pkg/workqueue"
 )
 
 func init() {
@@ -45,7 +44,6 @@ func InitNaiveController() error {
 
 	glog.V(4).Infof("Starting external ip controller using link: %s and mask: /%s", iface, mask)
 	stopCh := make(chan struct{})
-	q := workqueue.NewQueue()
 
 	var err error
 	var config *rest.Config
@@ -65,7 +63,7 @@ func InitNaiveController() error {
 		return err
 	}
 
-	c, err := externalip.NewExternalIpController(config, host, iface, mask, q)
+	c, err := externalip.NewExternalIpController(config, host, iface, mask, AppOpts.ResyncInterval)
 	if err != nil {
 		return err
 	}

--- a/cmd/app/options.go
+++ b/cmd/app/options.go
@@ -13,13 +13,18 @@
 // limitations under the License.
 package app
 
-import "github.com/spf13/pflag"
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
 
 type options struct {
-	Kubeconfig string
-	Iface      string
-	Mask       string
-	Hostname   string
+	Kubeconfig     string
+	Iface          string
+	Mask           string
+	Hostname       string
+	ResyncInterval time.Duration
 }
 
 var AppOpts = options{}
@@ -33,4 +38,5 @@ func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Mask, "mask", "32", "mask part of the cidr")
 	fs.StringVar(&o.Kubeconfig, "kubeconfig", "", "kubeconfig to use with kubernetes client")
 	fs.StringVar(&o.Hostname, "hostname", "", "We will use os.Hostname if none provided")
+	fs.DurationVar(&o.ResyncInterval, "resync", 20*time.Second, "Time to resync state for all ips")
 }


### PR DESCRIPTION
closes: https://github.com/Mirantis/k8s-externalipcontroller/issues/79

To change specify option `--resync` which by default is equal to 20s. 
To disable specify any zero value, like `--resync=0s`