### PR TITLE
Fix not found libpcap in containerized-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ ifeq ($(DOCKER_BUILD), yes)
 	_DOCKER_GOPATH = /go
 	_DOCKER_WORKDIR = $(_DOCKER_GOPATH)/src/github.com/Mirantis/k8s-externalipcontroller/
 	_DOCKER_IMAGE  = golang:1.7
+	_DOCKER_DEPS = apt-get update; apt-get install -y libpcap-dev;
 	DOCKER_EXEC = docker run --rm -it -v "$(ROOT_DIR):$(_DOCKER_WORKDIR)" \
-		-w "$(_DOCKER_WORKDIR)" $(_DOCKER_IMAGE)
+		-w "$(_DOCKER_WORKDIR)" $(_DOCKER_IMAGE) $(_DOCKER_DEPS)
 else
 	DOCKER_EXEC =
 endif
@@ -89,7 +90,7 @@ $(BUILD_DIR):
 
 
 $(BUILD_DIR)/ipmanager: $(BUILD_DIR) $(VENDOR_DIR)
-	$(DOCKER_EXEC) bash -xc 'apt-get update; apt-get install -y libpcap-dev; go build --ldflags "-extldflags \"-static\"" \
+	$(DOCKER_EXEC) bash -xc 'go build --ldflags "-extldflags \"-static\"" \
 		-o $@ ./cmd/ipmanager/ ; \
 		chown $(shell id -u):$(shell id -u) -R _output'
 

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,12 @@ ifeq ($(DOCKER_BUILD), yes)
 	_DOCKER_GOPATH = /go
 	_DOCKER_WORKDIR = $(_DOCKER_GOPATH)/src/github.com/Mirantis/k8s-externalipcontroller/
 	_DOCKER_IMAGE  = golang:1.7
-	_DOCKER_DEPS = apt-get update; apt-get install -y libpcap-dev;
+	DOCKER_DEPS = apt-get update; apt-get install -y libpcap-dev;
 	DOCKER_EXEC = docker run --rm -it -v "$(ROOT_DIR):$(_DOCKER_WORKDIR)" \
-		-w "$(_DOCKER_WORKDIR)" $(_DOCKER_IMAGE) $(_DOCKER_DEPS)
+		-w "$(_DOCKER_WORKDIR)" $(_DOCKER_IMAGE)
 else
 	DOCKER_EXEC =
+	DOCKER_DEPS =
 endif
 
 .PHONY: help
@@ -90,7 +91,8 @@ $(BUILD_DIR):
 
 
 $(BUILD_DIR)/ipmanager: $(BUILD_DIR) $(VENDOR_DIR)
-	$(DOCKER_EXEC) bash -xc 'go build --ldflags "-extldflags \"-static\"" \
+	$(DOCKER_EXEC) bash -xc '$(DOCKER_DEPS) \
+		go build --ldflags "-extldflags \"-static\"" \
 		-o $@ ./cmd/ipmanager/ ; \
 		chown $(shell id -u):$(shell id -u) -R _output'
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(BUILD_DIR):
 
 
 $(BUILD_DIR)/ipmanager: $(BUILD_DIR) $(VENDOR_DIR)
-	$(DOCKER_EXEC) bash -xc 'go build --ldflags "-extldflags \"-static\"" \
+	$(DOCKER_EXEC) bash -xc 'apt-get update; apt-get install -y libpcap-dev; go build --ldflags "-extldflags \"-static\"" \
 		-o $@ ./cmd/ipmanager/ ; \
 		chown $(shell id -u):$(shell id -u) -R _output'
 


### PR DESCRIPTION
Install libpcap-dev to golang container. Fix error:
```
$ sudo make containerized-build
......
Status: Downloaded newer image for golang:1.7
+ go build --ldflags '-extldflags "-static"' -o _output/ipmanager ./cmd/ipmanager/
# github.com/Mirantis/k8s-externalipcontroller/vendor/github.com/google/gopacket/pcap
vendor/github.com/google/gopacket/pcap/pcap.go:21:18: fatal error: pcap.h: No such file or directory
 #include <pcap.h>
                  ^
compilation terminated.
```