### PR TITLE
Fix invalid value ipnode.

### DIFF
--- a/pkg/claimcontroller/controller.go
+++ b/pkg/claimcontroller/controller.go
@@ -16,6 +16,7 @@ package claimcontroller
 
 import (
 	"time"
+	"strings"
 
 	"github.com/Mirantis/k8s-externalipcontroller/pkg/extensions"
 	"github.com/Mirantis/k8s-externalipcontroller/pkg/netutils"
@@ -50,6 +51,7 @@ func NewClaimController(iface, uid string, config *rest.Config, resyncInterval t
 		},
 	}
 	queue := workqueue.NewQueue()
+	uid = strings.Replace(uid, ".", "-", -1)
 	return &claimController{
 		Clientset:           clientset,
 		ExtensionsClientset: ext,


### PR DESCRIPTION
If the node domain contains a point, this error occurs (logging level 10):
```
I0105 21:26:08.223813       1 request.go:558] Request Body: "{\"kind\":\"IpNode\",\"apiVersion\":\"ipcontroller.ext/v1\",\"metadata\":{\"name\":\"kube1.domain.zone\",\"creationTimestamp\":null}}\n"
E0105 21:26:08.223835       1 request.go:568] Request.body: {"kind":"IpNode","apiVersion":"ipcontroller.ext/v1","metadata":{"name":"kube1.domain.zone","creationTimestamp":null}}
I0105 21:26:08.223937       1 round_trippers.go:299] curl -k -v -XPOST  -H "Accept: application/json, */*" -H "Content-Type: application/json" -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImRlZmF1bHQtdG9rZW4tN2pocTUiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoiZGVmYXVsdCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6ImZlNWExY2UyLWQzMjAtMTFlNi1hM2RhLTAwMjU5MDk5ZTkxYSIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0OmRlZmF1bHQifQ.Gx3w7DGAeq2_Vs1Xyj-g9UsHbiWyEDxMdyBZduH5KLz31uT_3BOELnkDi2jUlc07w-SELQm0UFxmXWDTnFo0ncNVl5kll2GY9s-pTAklqkErQ7XhyQKTfGEYq65MF3zx_jIt89iAwzZgoG0z4oJN6FfhU_Ml7QNfqXfM_608Qqn-WUxFTMiaIEKhJsmC6PVAqBxkMfIb3k3O4mmlf5INK51zkKO--pHRfDuLTupiZlJu8EVmRWwiK1k43RH3y75Ij1qRr-l2dJnYGYjaURHotKg36fFo9FUrs7JApfAUjF349fQOFezhNMFWLA2TwC12_MCYrdOdEOhgOjsF1CQ3Dw" https://10.96.0.1:443/apis/ipcontroller.ext/v1/namespaces/default/ipnodes
I0105 21:26:08.225067       1 round_trippers.go:318] POST https://10.96.0.1:443/apis/ipcontroller.ext/v1/namespaces/default/ipnodes 400 Bad Request in 1 milliseconds
I0105 21:26:08.225100       1 round_trippers.go:324] Response Headers:
I0105 21:26:08.225116       1 round_trippers.go:327]     Content-Type: application/json
I0105 21:26:08.225127       1 round_trippers.go:327]     Content-Length: 241
I0105 21:26:08.225134       1 round_trippers.go:327]     Date: Thu, 05 Jan 2017 21:26:08 GMT
I0105 21:26:08.225156       1 request.go:991] Response Body: "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"the object provided is unrecognized (must be of type ThirdPartyResourceData): unexpected end of JSON input (\\u003cempty\\u003e)\",\"reason\":\"BadRequest\",\"code\":400}\n"
E0105 21:26:08.225196       1 controller.go:166] Error creating node kube1.domain.zone : the server rejected our request for an unknown reason (post ipnodes.ipcontroller.ext)
```
A detailed error message:
```
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "ThirdPartyResourceData.extensions \"kube1.domain.zone\" is invalid: metadata.name: Invalid value: \"kube1.domain.zone\": must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])? (e.g. 'my-name' or '123-abc')",
  "reason": "Invalid",
  "details": {
    "name": "kube1.domain.zone",
    "group": "extensions",
    "kind": "ThirdPartyResourceData",
    "causes": [
      {
        "reason": "FieldValueInvalid",
        "message": "Invalid value: \"kube1.domain.zone\": must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])? (e.g. 'my-name' or '123-abc')",
        "field": "metadata.name"
      }
    ]
  }
```
This commit replaces all the points in the domain name on the dash for ipnode name.