### PR TITLE
Fix unmarshalling of integer values

### DIFF
--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -76,7 +76,7 @@ type IpNode struct {
 	Metadata api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// used as a heartbeat
-	Revision int64 `json:"generation,omitempty"`// protobuf:"varint,7,opt,name=revision"`
+	Revision int64 `json:"generation,omitempty" protobuf:"varint,7,opt,name=revision"`
 }
 
 func (e *IpNode) GetObjectKind() unversioned.ObjectKind {

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -76,7 +76,7 @@ type IpNode struct {
 	Metadata api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// used as a heartbeat
-	Revision int64 `json:"generation,omitempty" protobuf:"varint,7,opt,name=revision"`
+	Revision int64 `json:"generation,string"`
 }
 
 func (e *IpNode) GetObjectKind() unversioned.ObjectKind {

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -76,7 +76,7 @@ type IpNode struct {
 	Metadata api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// used as a heartbeat
-	Revision int64 `json:"generation,string"`
+	Revision int64 `json:",string"`
 }
 
 func (e *IpNode) GetObjectKind() unversioned.ObjectKind {

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -76,7 +76,7 @@ type IpNode struct {
 	Metadata api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// used as a heartbeat
-	Revision int64 `json:"generation,omitempty"`
+	Revision int64 `json:"generation,omitempty" protobuf:"varint,7,opt,name=revision"`
 }
 
 func (e *IpNode) GetObjectKind() unversioned.ObjectKind {

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -76,7 +76,7 @@ type IpNode struct {
 	Metadata api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// used as a heartbeat
-	Revision int64 `json:"generation,omitempty" protobuf:"varint,7,opt,name=revision"`
+	Revision int64 `json:"generation,omitempty"`// protobuf:"varint,7,opt,name=revision"`
 }
 
 func (e *IpNode) GetObjectKind() unversioned.ObjectKind {

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -1087,8 +1087,6 @@ var _ = Describe("Third party objects", func() {
 			_, err := ext.IPNodes().Update(&node)
 			Expect(err).NotTo(HaveOccurred())
 		}
-		//_, err = ext.IPNodes().List(api.ListOptions{})
-		//Expect(err).NotTo(HaveOccurred())
 	})
 })
 

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -681,7 +681,7 @@ var _ = Describe("Third party objects", func() {
 				return fmt.Errorf("Unexpected nodes length %v", ipnodes.Items)
 			}
 			return nil
-		}, time.Second * 30, 2 * time.Second).Should(BeNil())
+		}, time.Second*30, 2*time.Second).Should(BeNil())
 
 		By("deploying nginx pod and service with multiple external ips")
 		nginx1Name := "nginx1"
@@ -1079,6 +1079,16 @@ var _ = Describe("Third party objects", func() {
 			}
 			return nil
 		}, 30*time.Second, 1*time.Second).Should(BeNil())
+
+		ipnodes, err := ext.IPNodes().List(api.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		for _, node := range ipnodes.Items {
+			node.Revision = 10000000
+			newNode, err := ext.IPNodes().Update(node)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		_, err = ext.IPNodes().List(api.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 })
 

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -1087,8 +1087,8 @@ var _ = Describe("Third party objects", func() {
 			_, err := ext.IPNodes().Update(&node)
 			Expect(err).NotTo(HaveOccurred())
 		}
-		_, err = ext.IPNodes().List(api.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		//_, err = ext.IPNodes().List(api.ListOptions{})
+		//Expect(err).NotTo(HaveOccurred())
 	})
 })
 

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -1084,7 +1084,7 @@ var _ = Describe("Third party objects", func() {
 		Expect(err).NotTo(HaveOccurred())
 		for _, node := range ipnodes.Items {
 			node.Revision = 10000000
-			newNode, err := ext.IPNodes().Update(node)
+			_, err := ext.IPNodes().Update(&node)
 			Expect(err).NotTo(HaveOccurred())
 		}
 		_, err = ext.IPNodes().List(api.ListOptions{})


### PR DESCRIPTION
nmarshalling of IpNode.Revision could lead to
"json: cannot unmarshal number 1e+06 into Go value of type int64" error
as all numbers are treated as floats by default when scientific
notation is in use. Now it is fixed.

Closes: https://github.com/Mirantis/k8s-externalipcontroller/issues/128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-externalipcontroller/130)
<!-- Reviewable:end -->
